### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "moip/moip-sdk-php": "1.3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8.35",
         "mockery/mockery": "^0.9.4"
     },
     "autoload": {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -5,14 +5,14 @@ namespace Artesaos\Moip\Tests;
 use Artesaos\Moip\Moip;
 use Moip\Moip as Api;
 use Moip\Auth\BasicAuth;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MoipTestCase.
  *
  * @package Artesaos\Moip\Tests
  */
-abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends TestCase
 {
     /**
      * @const string


### PR DESCRIPTION
Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`. This will help us to migrate to `PHPUnit 6`, that **no longer supports** this namespace.
I just need to update to PHPUnit `4.8.35` that supports this namespace.